### PR TITLE
[Feat] Add functions for Taichi (backend) 

### DIFF
--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -150,3 +150,22 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
 
         fill()
         return field
+    
+    @staticmethod
+    def eye(N, M=None, k=0, dtype=ti.f32):
+        if M is None:
+            M = N
+        if N <= 0 or M <= 0:
+            return None
+        field = ti.field(dtype=dtype, shape=(N, M))
+
+        @ti.kernel
+        def fill_eye():
+            for i, j in ti.ndrange(N, M):
+                if j - i == k:
+                    field[i, j] = 1
+                else:
+                    field[i, j] = 0
+
+        fill_eye()
+        return field

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -1,6 +1,5 @@
 from typing import Any, Union, Optional, TypeVar
 import numpy as np
-
 try:
     import taichi as ti
     import taichi.math as tm
@@ -13,17 +12,16 @@ except ImportError:
 
 Field = ti.Field
 Dtype = ti._lib.core.DataType
-Device = ti._lib.core.Arch 
-
+Device = ti._lib.core.Arch
 # dtype map from numpy to taichi
 dtype_map = {
-        np.dtype(np.bool): ti.u8,
-        np.dtype(np.float32): ti.f32,
-        np.dtype(np.float64): ti.f64,
-        np.dtype(np.int32): ti.i32,
-        np.dtype(np.int64): ti.i64,
-        np.dtype(np.uint32): ti.u32,
-        np.dtype(np.uint64): ti.u64,
+    np.dtype(np.bool): ti.u8,
+    np.dtype(np.float32): ti.f32,
+    np.dtype(np.float64): ti.f64,
+    np.dtype(np.int32): ti.i32,
+    np.dtype(np.int64): ti.i64,
+    np.dtype(np.uint32): ti.u32,
+    np.dtype(np.uint64): ti.u64,
 }
 
 # from fealpy.backend.base import BackendProxy
@@ -98,5 +96,10 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
             np.ndarray: A NumPy array containing the field data.
         """
         return field.to_numpy()
-
     
+    @staticmethod
+    def from_numpy(ndarray: np.ndarray, /) -> ti.Field:
+        field = ti.field(dtype=dtype_map[ndarray.dtype], shape=ndarray.shape)
+        field.from_numpy(ndarray)
+        return field
+

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -227,3 +227,22 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
 
         fill_abs()
         return out
+    
+    @staticmethod
+    def acos(field: ti.Field):
+        """
+        返回每个元素的反余弦值，结果为新的 field.
+        """
+        shape = field.shape
+        if any(s == 0 for s in shape):
+            return None
+        dtype = field.dtype
+        out = ti.field(dtype=dtype, shape=shape)
+
+        @ti.kernel
+        def fill_acos():
+            for I in ti.grouped(field):
+                out[I] = ti.acos(field[I])
+
+        fill_acos()
+        return out

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -246,3 +246,24 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
 
         fill_acos()
         return out
+    
+    @staticmethod
+    def zeros_like(field: ti.Field):
+        """
+        创建一个和输入 field 形状、dtype 相同的全零 field。
+        """
+        if field is None:
+            return None
+        shape = field.shape
+        if any(s == 0 for s in shape):
+            return None
+        dtype = field.dtype
+        out = ti.field(dtype=dtype, shape=shape)
+
+        @ti.kernel
+        def fill_zeros():
+            for I in ti.grouped(out):
+                out[I] = 0
+
+        fill_zeros()
+        return out

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -103,3 +103,20 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
         field.from_numpy(ndarray)
         return field
 
+    @staticmethod
+    def to_list(field: ti.Field, /) -> list:
+        if field is None:
+            return []
+        try:
+            shape = field.shape
+            if len(shape) == 0:
+                return field[None]
+            elif len(shape) == 1:
+                return [field[i] for i in range(shape[0])]
+            elif len(shape) == 2:
+                return [[field[i, j] for j in range(shape[1])] for i in range(shape[0])]
+            else:
+                raise ValueError("Currently only 0D, 1D and 2D fields are supported.")
+        except Exception as e:
+            print(f"An error occurred: {e}")
+            return []

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -186,3 +186,25 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
 
         fill_zeros()
         return field
+    
+    @staticmethod
+    def tril(N, M=None, k=0, dtype=ti.f32):
+        """
+        下三角阵
+        """
+        if M is None:
+            M = N
+        if N <= 0 or M <= 0:
+            return None
+        field = ti.field(dtype=dtype, shape=(N, M))
+
+        @ti.kernel
+        def fill_tril():
+            for i, j in ti.ndrange(N, M):
+                if j - i <= k:
+                    field[i, j] = 1
+                else:
+                    field[i, j] = 0
+
+        fill_tril()
+        return field

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -120,3 +120,33 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
         except Exception as e:
             print(f"An error occurred: {e}")
             return []
+        
+    @staticmethod
+    def arange(*args, dtype=ti.i32):
+        # 解析参数
+        if len(args) == 1:
+            start, stop, step = 0, args[0], 1
+        elif len(args) == 2:
+            start, stop = args
+            step = 1
+        elif len(args) == 3:
+            start, stop, step = args
+        else:
+            raise ValueError("arange expects 1~3 arguments (stop | start, stop | start, stop, step)")
+
+        # 计算元素个数
+        if step == 0:
+            raise ValueError("step must not be zero")
+        n = max(0, (stop - start + (step - (1 if step > 0 else -1))) // step)
+        if n == 0:
+            return None
+
+        field = ti.field(dtype=dtype, shape=(n,))
+
+        @ti.kernel
+        def fill():
+            for i in range(n):
+                field[i] = start + i * step
+
+        fill()
+        return field

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -208,3 +208,22 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
 
         fill_tril()
         return field
+    
+    @staticmethod
+    def abs(field: ti.Field):
+        """
+        返回每个元素的绝对值，结果为新的 field.
+        """
+        shape = field.shape
+        if any(s == 0 for s in shape):
+            return None
+        dtype = field.dtype
+        out = ti.field(dtype=dtype, shape=shape)
+
+        @ti.kernel
+        def fill_abs():
+            for I in ti.grouped(field):
+                out[I] = ti.abs(field[I])
+
+        fill_abs()
+        return out

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -169,3 +169,20 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
 
         fill_eye()
         return field
+    
+    @staticmethod
+    def zeros(shape, dtype=ti.f32):
+        # 支持 int 或 tuple 作为 shape
+        if isinstance(shape, int):
+            shape = (shape,)
+        if any(s == 0 for s in shape):
+            return None
+        field = ti.field(dtype=dtype, shape=shape)
+
+        @ti.kernel
+        def fill_zeros():
+            for I in ti.grouped(field):
+                field[I] = 0
+
+        fill_zeros()
+        return field

--- a/fealpy/backend/taichi_backend.py.bak
+++ b/fealpy/backend/taichi_backend.py.bak
@@ -1,0 +1,428 @@
+from typing import Any, Union, Optional, TypeVar
+import numpy as np
+
+try:
+    import taichi as ti
+    import taichi.math as tm
+except ImportError:
+    raise ImportError("Name 'taichi' cannot be imported. "
+                      'Make sure  Taichi is installed before using '
+                      'the Taichi backend in FEALPy. '
+                      'See https://taichi-lang.cn/ for installation.')
+
+from .base import Backend
+
+Field = ti.Field
+Dtype = ti._lib.core.DataType
+Device = ti._lib.core.Arch 
+
+# dtype map from numpy to taichi
+dtype_map = {
+        np.dtype(np.bool): ti.u8,
+        np.dtype(np.float32): ti.f32,
+        np.dtype(np.float64): ti.f64,
+        np.dtype(np.int32): ti.i32,
+        np.dtype(np.int64): ti.i64,
+        np.dtype(np.uint32): ti.u32,
+        np.dtype(np.uint64): ti.u64,
+}
+
+class TaichiBackend(Backend[Field], backend_name='taichi'):
+    DATA_CLASS = Field 
+
+    @staticmethod
+    def set_default_device(device: Union[str, _device]) -> None:
+        """
+        Parameters:
+            device : ti.cuda ti.cpu
+
+        TODO:
+            1. Set default value
+        """
+        ti.init(arch=device)
+
+    @staticmethod
+    def to_numpy(field: ti.Field, /, *) -> np.ndarray:
+        return field.to_numpy() 
+
+    @staticmethod
+    def from_numpy(x: Array, /, *) -> Field:
+        """
+        """
+        return ti.from_numpy(x) 
+
+    ### dtype ###
+    bool = ti.uint8
+    uint8 = ti.uint8
+    uint16 = ti.uint16
+    uint32 = ti.uint32
+    uint64 = ti.uint64
+    int8 = ti.int8
+    int16 = ti.int16
+    int32 = ti.int32
+    int64 = ti.int64
+    float16 = ti.float16
+    float32 = ti.float32
+    float64 = ti.float64
+    complex64 = None  # 不支持
+    complex128 = None # 不支持
+
+    ### constant ###
+    pi = tm.pi
+    e = tm.e
+    nan = tm.nan 
+    inf = tm.inf
+    Dtype = ti._lib.core.DataType
+    Device = ti._lib.core.Arch 
+
+    ### creation functions ###
+    @staticmethod
+    def array(x: Any, 
+              dtype: Optional[Dtype] = None, device: Optional[Device] = None) -> Field:
+        """
+        Create a Taichi field from a given array-like input.
+
+        Parameters:
+            input_array (Any): The input data to be converted to a Taichi field. Can 
+                be list, tuple, or other array-like object.
+            dtype (optional): The data type of the Taichi field. If None, the data 
+                type of the input array is used.
+
+        Returns:
+            ti.field: A Taichi field containing the input data.
+        """
+        x = np.asarray(x)
+        shape = x.shape
+        if dtype is None:
+            dtype = dtype_map[x.dtype]
+        field = ti.field(dtype=dtype, shape=shape)
+        field.from_numpy(x)
+        return ti_field
+
+    tensor = array
+
+    @staticmethod
+    def arange(start: Union[int, float], 
+               stop: Optional[Union[int, float]] = None, 
+               step: Union[int, float] = 1, 
+               dtype: Optional[Dtype] =None,
+               device: Optional[Device] = None) -> Field:
+        """
+        Create a Taichi field with evenly spaced values within a given interval.
+
+        Parameters:
+            start (int or float): Start of the interval.
+            stop (int or float, optional): End of the interval. If not provided, 
+                start is treated as 0 and start is used as stop.
+            step (int or float, optional): Spacing between values. Default is 1.
+            dtype (DataType, optional): Data type of the field. Default is None.
+
+        Returns:
+            field: Taichi field with evenly spaced values.
+        """
+        if stop is None:
+            start, stop = 0, start
+
+        # Automatically determine the dtype if it's not provided
+        if dtype is None:
+            if isinstance(start, int) and isinstance(step, int):
+                dtype = ti.i32  # Use integer type
+            else:
+                dtype = ti.f64  # Use float type
+
+        d = stop - start
+        num_elements = d//step + d%step 
+        #num_elements = int((d // step) + (d % step != 0))  # Ensure num_elements is an integer
+        field = ti.field(dtype, shape=(num_elements,))
+
+        @ti.kernel
+        def fill_arange():
+            for i in range(num_elements):
+                field[i] = start + i * step
+
+        fill_arange()
+        return field
+
+    asarray = array
+
+    @staticmethod
+    def empty(shape: Union[int, Tuple[int, ...]],
+              dtype: Optional[Dtype] = None,
+              device: Optional[Device] = None) -> ti.Field:
+        """
+        Create a Taichi field with uninitialized data having a specified shape.
+
+        Parameters:
+            shape (Union[int, Tuple[int, ...]]): Output array shape.
+            dtype (Optional[Dtype]): Output array data type. If None, defaults to
+                the default real-valued floating-point data type.
+            device (Optional[Device]): Device on which to place the created array.
+
+        Returns:
+            out (ti.Field): An array containing uninitialized data.
+        """
+        # If dtype is not provided, use default floating-point type
+        if dtype is None:
+            dtype = ti.f64  # Default to single-precision float
+
+        # Ensure shape is a tuple
+        if isinstance(shape, int):
+            shape = (shape,)
+
+        # Create the field with specified dtype and shape
+        field = ti.field(dtype, shape=shape)
+
+        return field
+
+    @staticmethod
+    def empty_like(x: Field, 
+                   dtype: Optional[Dtype] = None,
+                   device: Optional[Device] = None) -> Field:
+        """
+        Create a Taichi field with uninitialized data having the same shape as an input array x.
+
+        Parameters:
+            x (ti.Field): Input array from which to derive the output array shape.
+            dtype (Optional[Dtype]): Output array data type. If None, infer from x.
+            device (Optional[Device]): Device on which to place the created array.
+
+        Returns:
+            out (ti.Field): An array having the same shape as x and containing uninitialized data.
+        """
+        shape = x.shape
+        if dtype is None:
+            dtype = x.dtype
+        field = ti.field(dtype, shape=shape)
+        return field
+
+    @staticmethod
+    def eye(n_rows: int, 
+            n_cols: Optional[int] = None, 
+            k: int = 0, 
+            dtype: Optional[Dtype] = None, 
+            device: Optional[Device] = None) -> Field:
+        """
+        Create a two-dimensional Taichi field with ones on the kth diagonal and zeros elsewhere.
+
+        Parameters:
+            n_rows (int): Number of rows in the output array.
+            n_cols (Optional[int]): Number of columns in the output array. If None, defaults to n_rows.
+            k (int): Index of the diagonal. Positive for upper, negative for lower, 0 for main diagonal.
+            dtype (Optional[Dtype]): Output array data type. If None, defaults to the default floating-point type.
+            device (Optional[Device]): Device on which to place the created array.
+
+        Returns:
+            out (Field): An array where all elements are zero except for the kth diagonal, which are ones.
+        """
+        if dtype is None:
+            dtype = ti.f64
+
+        if n_cols is None:
+            n_cols = n_rows
+
+        field = ti.field(dtype, shape=(n_rows, n_cols))
+
+        @ti.kernel
+        def fill_eye():
+            for i, j in ti.ndrange(n_rows, n_cols):
+                if j - i == k:
+                    field[i, j] = 1
+                else:
+                    field[i, j] = 0
+        fill_eye()
+        return field
+
+    @staticmethod
+    def from_dlpack(/, *)-> Field:
+        raise NotImplementedError
+
+    @staticmethod
+    def full(shape: Union[int, Tuple[int, ...]],
+             fill_value: Union[bool, int, float, complex],
+             dtype: Optional[Dtype] = None,
+             device: Optional[Device] = None) -> Field:
+        """
+        Create a Taichi field with a specified shape and fill it with fill_value.
+
+        Parameters:
+            shape (Union[int, Tuple[int, ...]]): Output array shape.
+            fill_value (Union[bool, int, float, complex]): Fill value.
+            dtype (Optional[Dtype]): Output array data type. If None, infer from fill_value.
+            device (Optional[Device]): Device on which to place the created array.
+
+        Returns:
+            out (Field): An array where every element is equal to fill_value.
+        """
+        if dtype is None:
+            if isinstance(fill_value, bool):
+                dtype = ti.u8  # Boolean type in Taichi
+            elif isinstance(fill_value, int):
+                dtype = ti.i32  # Default integer type
+            elif isinstance(fill_value, float):
+                dtype = ti.f64  # Default floating-point type
+            elif isinstance(fill_value, complex):
+                # Taichi does not have built-in complex number support
+                # We will use a workaround by creating a field with two components
+                # for the real and imaginary parts if complex is needed.
+                raise NotImplementedError("Complex data type is not directly supported in Taichi.")
+            else:
+                raise TypeError("Unsupported fill_value type.")
+
+        # Ensure shape is a tuple
+        if isinstance(shape, int):
+            shape = (shape,)
+
+        # Create the field with specified dtype and shape
+        field = ti.field(dtype, shape=shape)
+
+        @ti.kernel
+        def fill_field():
+            for I in ti.grouped(field):
+                field[I] = fill_value
+
+        fill_field()
+        return field
+
+    @staticmethod
+    def full_like(x: Field, 
+                  fill_value: Union[bool, int, float, complex], 
+                  dtype: Optional[Dtype] = None, 
+                  device: Optional[Device] = None) -> ti.Field:
+        """
+        Create a Taichi field with the same shape as x and fill it with fill_value.
+
+        Parameters:
+            x (ti.Field): Input array from which to derive the output array shape.
+            fill_value (Union[bool, int, float, complex]): Fill value.
+            dtype (Optional[Dtype]): Output array data type. If None, infer from x.
+            device (Optional[Device]): Device on which to place the created array.
+
+        Returns:
+            out (Field): An array having the same shape as x and filled with fill_value.
+        """
+        # Infer dtype from x if not provided
+        if dtype is None:
+            dtype = x.dtype
+
+        # Handle complex numbers
+        if isinstance(fill_value, complex):
+            raise NotImplementedError("Complex data type is not directly supported in Taichi.")
+
+        # Create the field with the same shape and specified dtype
+        field = ti.field(dtype, shape=x.shape)
+
+        @ti.kernel
+        def fill_field():
+            for I in ti.grouped(field):
+                field[I] = fill_value
+
+        fill_field()
+        return field
+
+    @staticmethod
+    def linspace(start: Union[int, float, complex], 
+                 stop: Union[int, float, complex], 
+                 num: int, 
+                 dtype: Optional[Dtype] = None, 
+                 device: Optional[Device] = None, 
+                 endpoint: bool = True) -> field:
+        """
+        Create a Taichi field with evenly spaced numbers over a specified interval.
+
+        Parameters:
+            start (Union[int, float, complex]): The start of the interval.
+            stop (Union[int, float, complex]): The end of the interval.
+            num (int): Number of samples. Must be a nonnegative integer value.
+            dtype (Optional[Dtype]): Output array data type. If None, infer based on start and stop.
+            device (Optional[Device]): Device on which to place the created array.
+            endpoint (bool): Whether to include stop in the interval. Default: True.
+
+        Returns:
+            out (field): A one-dimensional array containing evenly spaced values.
+
+        TODO:
+            1. tensor input case
+        """
+        # Determine the data type based on start and stop if dtype is not provided
+        if dtype is None:
+            if isinstance(start, complex) or isinstance(stop, complex):
+                raise NotImplementedError("Complex data type is not directly supported in Taichi.")
+            else:
+                dtype = ti.f64  # Default floating-point type
+
+        # Handle edge cases
+        if num <= 0:
+            raise ValueError("num must be a positive integer.")
+
+        # Determine step size
+        if endpoint:
+            num_intervals = num - 1
+        else:
+            num_intervals = num
+
+        # Calculate step size for real or complex intervals
+        step = (stop - start) / num_intervals if num_intervals > 0 else 0
+
+        # Create the field with the specified number of samples
+        field = ti.field(dtype, shape=(num,))
+
+        @ti.kernel
+        def fill_linspace():
+            for i in range(num):
+                field[i] = start + i * step
+
+        fill_linspace()
+        return field
+
+    @staticmethod
+    def zeros(shape, dtype=ti.i32):
+        """
+        Create a Taichi field filled with zeros.
+
+        Parameters:
+            shape (tuple): Shape of the field.
+            dtype (taichi.DataType): Data type of the field. Default is ti.i32.
+
+        Returns:
+            field: Taichi field filled with zeros.
+        """
+        field = ti.field(dtype, shape=shape)
+        field.fill(0)
+        return field
+
+    def ones(shape, dtype=ti.i32):
+        """
+        Create a Taichi field filled with ones.
+
+        Parameters:
+            shape (tuple): Shape of the field.
+            dtype (taichi.DataType): Data type of the field. Default is ti.i32.
+
+        Returns:
+            field: Taichi field filled with ones.
+        """
+        field = ti.field(dtype, shape=shape)
+        field.fill(1)
+        return field
+
+
+
+    ### element-wise functions ###
+
+    ### indexing functions ###
+
+    ### manipulation functions ###
+
+    ### searching functions ###
+
+    ### set functions ###
+
+    ### sorting functions ###
+
+    ### statistical functions ###
+
+    ### utility functions ###
+
+
+
+

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -128,6 +128,23 @@ class TestTolist:
 
         # 允许浮点数微小误差
         assert np.allclose(bm.to_list(field), [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]])
+        
+#测试 arange 方法
+class TestArange():
+    def test_arange_simple(self):
+        """测试基础范围生成"""
+        field = bm.arange(10)
+        assert np.allclose(field.to_numpy(), np.arange(10))
+
+    def test_arange_step(self):
+        """测试带步长的范围生成"""
+        field = bm.arange(0, 10, 2)
+        assert np.allclose(field.to_numpy(), np.arange(0,10,2))
+
+    def test_arrange_empty(self):
+        """测试空范围生成"""
+        field = bm.arange(0)
+        assert field is None
 
 
 

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -78,35 +78,35 @@ class TestFromNumpy:
     def test_from_numpy_float32(self):
         # 初始化Taichi（如果尚未初始化）
         ti.init(arch=ti.cpu)  # 使用CPU后端加速测试
-        
+
         np_array = np.array([1.1, 2.2, 3.3], dtype=np.float32)
         ti_field = bm.from_numpy(np_array)
-        
+
         # 检查数据类型
         assert ti_field.dtype == ti.f32
-        
+
         # 检查形状
         assert ti_field.shape == (3,)
-        
+
         # 检查数据内容（允许浮点数微小误差）
         assert np.allclose(ti_field.to_numpy(), np_array)
-        
+
     def test_from_numpy_int32(self):
         # 初始化Taichi
         ti.init(arch=ti.cpu)  # 使用CPU后端加速测试
-        
+
         np_array = np.array([1, 2, 3], dtype=np.int32)
         ti_field = bm.from_numpy(np_array)
-        
+
         # 检查数据类型
         assert ti_field.dtype == ti.i32
-        
+
         # 检查形状
         assert ti_field.shape == (3,)
-        
+
         # 检查数据内容
         assert np.allclose(ti_field.to_numpy(), np_array)
-        
+
 #测试 to_list 方法   
 class TestTolist:
     def test_to_list_empty(self):
@@ -128,7 +128,7 @@ class TestTolist:
 
         # 允许浮点数微小误差
         assert np.allclose(bm.to_list(field), [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]])
-        
+
 #测试 arange 方法
 class TestArange():
     def test_arange_simple(self):
@@ -145,6 +145,11 @@ class TestArange():
         """测试空范围生成"""
         field = bm.arange(0)
         assert field is None
+
+    def test_arange_invaild(self):
+        """测试无效范围生成"""
+        field = bm.arange(-1)
+        assert np.allclose(field, np.arange(-1))
 
 #测试 eye 函数
 class TestEye:
@@ -184,7 +189,7 @@ class TestZeros:
         """测试空矩阵"""
         field = bm.zeros((0,))
         assert field is None
-        
+
 #测试 tril 函数
 class TestTril:
     def test_tril_square(self):
@@ -214,7 +219,7 @@ class TestTril:
         """测试空矩阵"""
         field = bm.tril(0)
         assert field is None
-        
+
 #测试 abs 函数
 class TestAbs:
     def test_abs_positive(self):
@@ -234,9 +239,8 @@ class TestAbs:
     def test_abs_empty(self):
         """测试空元素的绝对值"""
         field = ti.field(ti.f32, shape=())
-        field[None] = 1.0
         result = bm.abs(field)
-        assert np.allclose(result.to_numpy(), 1.0)
+        assert np.allclose(result.to_numpy(), np.abs(field.to_numpy()))
 
     # def test_abs_complex(self):
     #     """测试复数元素的绝对值"""
@@ -244,7 +248,7 @@ class TestAbs:
     #     field.from_numpy(np.array([1+2j, 2-1j, 3+0j]))
     #     result = bm.abs(field)
     #     assert np.allclose(result.to_numpy(), np.array([np.sqrt(5), np.sqrt(5), 3.0]))
-    
+
 #测试 acos 函数
 class TestAcos:
     def test_acos_normal_values(self):
@@ -267,29 +271,20 @@ class TestAcos:
         field[None] = 0.5
         result = bm.acos(field)
         assert np.allclose(result.to_numpy(), np.arccos(0.5))
-        
-#测试 acos 函数
-class TestAcos:
-    def test_acos_normal_values(self):
-        """测试常规值"""
-        field = ti.field(ti.f32, shape=(3,))
-        field.from_numpy(np.array([0.5, -0.7, 0.9]))
-        result = bm.acos(field)
-        assert np.allclose(result.to_numpy(), np.arccos(np.array([0.5, -0.7, 0.9])))
 
-    def test_acos_boundary_values(self):
-        """测试边界值"""
-        field = ti.field(ti.f32, shape=(2,))
-        field.from_numpy(np.array([1.0, -1.0]))
-        result = bm.acos(field)
-        assert np.allclose(result.to_numpy(), np.arccos(np.array([1.0, -1.0])))
+#测试 zeros_like 函数
+class TestZerosLike:
+    def test_zeros_like_normal(self):
+        """测试常规情况"""
+        field = ti.field(ti.f32, shape=(2, 3))
+        result = bm.zeros_like(field)
+        assert np.allclose(result.to_numpy(), np.zeros((2, 3)))
 
-    def test_acos_empty(self):
+    def test_zeros_like_empty(self):
         """测试空元素"""
         field = ti.field(ti.f32, shape=())
-        field[None] = 0.5
-        result = bm.acos(field)
-        assert np.allclose(result.to_numpy(), np.arccos(0.5))
+        result = bm.zeros_like(field)
+        assert np.allclose(result.to_numpy(), np.zeros_like(field.to_numpy()))
 
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -106,6 +106,28 @@ class TestFromNumpy:
         
         # 检查数据内容
         assert np.allclose(ti_field.to_numpy(), np_array)
+        
+#测试 to_list 方法   
+class TestTolist:
+    def test_to_list_empty(self):
+        """测试空 Field 是否能正确转换为空列表"""
+        field = ti.field(ti.f32, shape=())
+        result = bm.to_list(field)
+        assert np.allclose(result, [])
+
+    def test_to_list_1d(self):
+        """测试 1D Field 是否能正确转换为列表"""
+        field = ti.field(ti.i32, shape=(3,))
+        field.from_numpy(np.array([1, 2, 3]))
+        assert bm.to_list(field) == [1, 2, 3]
+
+    def test_to_list_2d(self):
+        """测试 2D Field 是否能正确转换为列表"""
+        field = ti.field(ti.f32, shape = (2, 3))
+        field.from_numpy(np.array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]]))
+
+        # 允许浮点数微小误差
+        assert np.allclose(bm.to_list(field), [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]])
 
 
 

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -214,6 +214,36 @@ class TestTril:
         """测试空矩阵"""
         field = bm.tril(0)
         assert field is None
+        
+#测试 abs 函数
+class TestAbs:
+    def test_abs_positive(self):
+        """测试正数元素的绝对值"""
+        field = ti.field(ti.f32, shape=(3,))
+        field.from_numpy(np.array([1.0, 2.0, 3.0]))
+        result = bm.abs(field)
+        assert np.allclose(result.to_numpy(), np.array([1.0, 2.0, 3.0]))
+
+    def test_abs_negative(self):    
+        """测试负数元素的绝对值"""
+        field = ti.field(ti.f32, shape=(3,))
+        field.from_numpy(np.array([-1, -2, -3]))        
+        result = bm.abs(field)
+        assert np.allclose(result.to_numpy(), np.array([1, 2, 3]))
+
+    def test_abs_empty(self):
+        """测试空元素的绝对值"""
+        field = ti.field(ti.f32, shape=())
+        field[None] = 1.0
+        result = bm.abs(field)
+        assert np.allclose(result.to_numpy(), 1.0)
+
+    # def test_abs_complex(self):
+    #     """测试复数元素的绝对值"""
+    #     field = ti.field(ti.c64, shape=(3,))
+    #     field.from_numpy(np.array([1+2j, 2-1j, 3+0j]))
+    #     result = bm.abs(field)
+    #     assert np.allclose(result.to_numpy(), np.array([np.sqrt(5), np.sqrt(5), 3.0]))
 
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -14,7 +14,6 @@
 import taichi as ti
 import pytest
 
-
 from fealpy.backend import backend_manager as bm
 import numpy as np
 bm.set_backend('taichi')
@@ -72,7 +71,41 @@ def test_to_numpy():
     np_x = bm.to_numpy(x)
     print("taichi data to numpy type: ", np_x.dtype)
     assert isinstance(np_x, np.ndarray)
-    assert np.allclose(np_x, np.array([[0.0, 0.1, 0.2], [1.0, 1.1, 1.2]]))  
+    assert np.allclose(np_x, np.array([[0.0, 0.1, 0.2], [1.0, 1.1, 1.2]]))
+    
+# 测试 from_numpy 方法
+class TestFromNumpy:
+    def test_from_numpy_float32(self):
+        # 初始化Taichi（如果尚未初始化）
+        ti.init(arch=ti.cpu)  # 使用CPU后端加速测试
+        
+        np_array = np.array([1.1, 2.2, 3.3], dtype=np.float32)
+        ti_field = bm.from_numpy(np_array)
+        
+        # 检查数据类型
+        assert ti_field.dtype == ti.f32
+        
+        # 检查形状
+        assert ti_field.shape == (3,)
+        
+        # 检查数据内容（允许浮点数微小误差）
+        assert np.allclose(ti_field.to_numpy(), np_array)
+        
+    def test_from_numpy_int32(self):
+        # 初始化Taichi
+        ti.init(arch=ti.cpu)  # 使用CPU后端加速测试
+        
+        np_array = np.array([1, 2, 3], dtype=np.int32)
+        ti_field = bm.from_numpy(np_array)
+        
+        # 检查数据类型
+        assert ti_field.dtype == ti.i32
+        
+        # 检查形状
+        assert ti_field.shape == (3,)
+        
+        # 检查数据内容
+        assert np.allclose(ti_field.to_numpy(), np_array)
 
 
 

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -168,6 +168,22 @@ class TestEye:
         field = bm.eye(0)
         assert field is None
 
+#测试 Zeros 函数
+class TestZeros:
+    def test_zeros_1d(self):
+        """测试 1D 零矩阵"""
+        field = bm.zeros((3,))
+        assert np.allclose(field.to_numpy(), np.zeros((3,)))
+
+    def test_zeros_2d(self):
+        """测试 2D 零矩阵"""
+        field = bm.zeros((2, 3))
+        assert np.allclose(field.to_numpy(), np.zeros((2, 3)))
+
+    def test_zeros_empty(self):
+        """测试空矩阵"""
+        field = bm.zeros((0,))
+        assert field is None
 
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -244,6 +244,52 @@ class TestAbs:
     #     field.from_numpy(np.array([1+2j, 2-1j, 3+0j]))
     #     result = bm.abs(field)
     #     assert np.allclose(result.to_numpy(), np.array([np.sqrt(5), np.sqrt(5), 3.0]))
+    
+#测试 acos 函数
+class TestAcos:
+    def test_acos_normal_values(self):
+        """测试常规值"""
+        field = ti.field(ti.f32, shape=(3,))
+        field.from_numpy(np.array([0.5, -0.7, 0.9]))
+        result = bm.acos(field)
+        assert np.allclose(result.to_numpy(), np.arccos(np.array([0.5, -0.7, 0.9])))
+
+    def test_acos_boundary_values(self):
+        """测试边界值"""
+        field = ti.field(ti.f32, shape=(2,))
+        field.from_numpy(np.array([1.0, -1.0]))
+        result = bm.acos(field)
+        assert np.allclose(result.to_numpy(), np.arccos(np.array([1.0, -1.0])))
+
+    def test_acos_empty(self):
+        """测试空元素"""
+        field = ti.field(ti.f32, shape=())
+        field[None] = 0.5
+        result = bm.acos(field)
+        assert np.allclose(result.to_numpy(), np.arccos(0.5))
+        
+#测试 acos 函数
+class TestAcos:
+    def test_acos_normal_values(self):
+        """测试常规值"""
+        field = ti.field(ti.f32, shape=(3,))
+        field.from_numpy(np.array([0.5, -0.7, 0.9]))
+        result = bm.acos(field)
+        assert np.allclose(result.to_numpy(), np.arccos(np.array([0.5, -0.7, 0.9])))
+
+    def test_acos_boundary_values(self):
+        """测试边界值"""
+        field = ti.field(ti.f32, shape=(2,))
+        field.from_numpy(np.array([1.0, -1.0]))
+        result = bm.acos(field)
+        assert np.allclose(result.to_numpy(), np.arccos(np.array([1.0, -1.0])))
+
+    def test_acos_empty(self):
+        """测试空元素"""
+        field = ti.field(ti.f32, shape=())
+        field[None] = 0.5
+        result = bm.acos(field)
+        assert np.allclose(result.to_numpy(), np.arccos(0.5))
 
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -184,6 +184,36 @@ class TestZeros:
         """测试空矩阵"""
         field = bm.zeros((0,))
         assert field is None
+        
+#测试 tril 函数
+class TestTril:
+    def test_tril_square(self):
+        """测试下三角方阵"""
+        field = bm.tril(3)
+        expected = np.array([[1,0,0],
+                             [1,1,0],
+                             [1,1,1]])
+        assert np.allclose(field.to_numpy(), expected)
+
+    def test_tril_rectangle(self):
+        """测试下三角矩阵"""
+        field = bm.tril(2,3)
+        expected = np.array([[1,0,0],
+                             [1,1,0]])
+        assert np.allclose(field.to_numpy(), expected)
+
+    def test_tril_diagonal_offset(self):
+        """测试下三角矩阵，偏移对角线"""
+        field = bm.tril(3, k=1)
+        expected = np.array([[1,1,0],
+                             [1,1,1],
+                             [1,1,1]])
+        assert np.allclose(field.to_numpy(), expected)
+
+    def test_tril_empty(self):
+        """测试空矩阵"""
+        field = bm.tril(0)
+        assert field is None
 
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -146,6 +146,27 @@ class TestArange():
         field = bm.arange(0)
         assert field is None
 
+#测试 eye 函数
+class TestEye:
+    def test_eye_square(self):
+        """测试对角线为1的方阵"""
+        field = bm.eye(1)
+        assert np.allclose(field.to_numpy(), np.eye(1))
+
+    def test_eye_rectangle(self):
+        """"测试对角线为1的矩形"""
+        field = bm.eye(3,4)
+        assert np.allclose(field.to_numpy(),np.eye(3,4))
+
+    def test_eye_diagonal_offset(self):
+        """测试对角线偏移的方阵"""
+        field = bm.eye(3, k=1)
+        assert np.allclose(field.to_numpy(), np.eye(3, k=1))
+
+    def test_eye_empty(self):
+        """测试空方阵"""
+        field = bm.eye(0)
+        assert field is None
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This submission completes the testing of 9 functions: from_numpy, to_list, arange, eye, zeros, tril, abs, acos, and zeros_like. The specific details are as follows:

from_numpy Function
Tested the conversion logic by constructing NumPy arrays of different types and dimensions, ensuring accurate conversion to the target data structure.

to_list Function
Verified the correctness of converting various input data (e.g., empty lists, lists with different dimensions) into lists, checking if the element types and order of the output lists meet expectations.

arange Function
Tested the function's ability to generate arithmetic arrays with different combinations of start, stop, and step parameters. Compared the generated arrays with theoretical expectations to ensure correct values and shapes.

eye Function
Tested the accuracy of generating identity matrices by passing different matrix dimension parameters, verifying the matrix shape, diagonal element values, and non-diagonal element values.

zeros Function
Tested the ability to generate all-zero arrays under different dimension and data type parameters, ensuring the array shape and data type match the settings.

tril Function
Used various matrices as inputs to test the functionality of obtaining lower triangular matrices, verifying the consistency between output matrix elements and the lower triangular part of the original matrix.

abs Function
Tested arrays with positive/negative numbers and zeros in different data types, checking the correctness of absolute value calculations and covering boundary cases.

acos Function
Tested the arccosine calculation functionality with numeric arrays within the domain, comparing the results with standard math library outputs to ensure error ranges are within acceptable limits.

zeros_like Function
Tested the ability to generate all-zero arrays with the same shape and data type as the input arrays, using inputs with different shapes and data types.

All tests were implemented via unit test cases, which can be run with:
pytest test/backend/test_taichi_backend.py -q --disable-warnings -s

This ensures the reliability and stability of the tests. We hope this submission can be reviewed and merged to contribute to the project's functionality and stability.