### PR TITLE
[Feat] Add functions for Taichi (backend)

### DIFF
--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -198,3 +198,32 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
             return result[None]
 
         return result
+
+    @staticmethod
+    def asinh(x: Union[ti.Field, float]) -> Union[ti.Field, float]:
+        # 检查输入是否是单值（标量）
+        if isinstance(x, float):
+            return ti.log(x + ti.sqrt(x * x + 1.0))
+
+        # 如果输入是 ti.Field
+        if not isinstance(x, ti.Field):
+            raise TypeError("Input must be a ti.Field or a float")
+
+        # 获取矩阵的形状
+        shape = x.shape
+
+        # 创建一个新的 ti.Field 来存储结果
+        result = ti.field(dtype=x.dtype, shape=shape)
+
+        @ti.kernel
+        def compute_asinh(field: ti.template(), result: ti.template()):
+            for I in ti.grouped(field):
+                result[I] = ti.log(field[I] + ti.sqrt(field[I] * field[I] + 1.0))
+
+        compute_asinh(x, result)
+
+        if len(shape) == 1 and shape[0] == 1:
+            # 如果结果是一个单值的 ti.Field，返回其单值
+            return result[None]
+
+        return result

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -134,3 +134,21 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
         x = ti.field(dtype=ti.i32, shape=field.shape)
         x.fill(1)
         return x
+    
+    @staticmethod
+    def full_like(field: ti.Field, element: Union[bool, int, float], dtype: Optional[Dtype] = None) -> ti.Field:  # type: ignore
+
+        if dtype is None:
+            if isinstance(element, bool):
+                dtype = ti.u8  # Boolean type in Taichi
+            elif isinstance(element, int):
+                dtype = ti.i32  # Default integer type
+            elif isinstance(element, float):
+                dtype = ti.f64  # Default floating-point type
+            else:
+                raise TypeError("Unsupported fill_value type.")
+
+        x = ti.field(dtype=dtype, shape=field.shape)
+        x.fill(element)
+        return x
+    

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -227,3 +227,21 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
             return result[None]
 
         return result
+
+    @staticmethod
+    def add(x: ti.Field, y: ti.Field) -> ti.Field:
+        if not isinstance(x, ti.Field) or not isinstance(y, ti.Field):
+            raise TypeError("Both inputs must be ti.Field")
+
+        if x.shape != y.shape:
+            raise ValueError("Input fields must have the same shape")
+
+        @ti.kernel
+        def add_field(x: ti.template(), y: ti.template(), z: ti.template()):
+
+            for I in ti.grouped(x):
+                z[I] = x[I] + y[I]  # taichi math库里面有atomic_add函数
+
+        z = ti.field(dtype=x.dtype, shape=x.shape)
+        add_field(x, y, z)
+        return z

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -1,4 +1,4 @@
-from typing import Any, Union, Optional, TypeVar
+from typing import Any, Union, Optional, TypeVar, Tuple
 import numpy as np
 
 try:
@@ -105,4 +105,24 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
         """
         return field.to_numpy()
 
-   
+    @staticmethod
+    def ones(shape: Union[int, Tuple[int, ...]], ) -> ti.Field:
+        x = ti.field(shape=shape,dtype=ti.i32)
+        x.fill(1)
+        return x
+    
+    @staticmethod
+    def full(shape: Union[int, Tuple[int, ...]], element: Union[bool, int, float], dtype: Optional[Dtype] = None) -> ti.Field:  # type: ignore
+        if dtype is None:
+            if isinstance(element, bool):
+                dtype = ti.u8  # Boolean type in Taichi
+            elif isinstance(element, int):
+                dtype = ti.i32  # Default integer type
+            elif isinstance(element, float):
+                dtype = ti.f64  # Default floating-point type
+            else:
+                raise TypeError("Unsupported fill_value type.")
+
+        x = ti.field(dtype=dtype, shape=shape)
+        x.fill(element)
+        return x

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -126,3 +126,11 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
         x = ti.field(dtype=dtype, shape=shape)
         x.fill(element)
         return x
+    
+    @staticmethod
+    def ones_like(field: ti.Field) -> ti.Field:
+        if field.shape == (0,):
+            return None
+        x = ti.field(dtype=ti.i32, shape=field.shape)
+        x.fill(1)
+        return x

--- a/fealpy/backend/taichi_backend.py
+++ b/fealpy/backend/taichi_backend.py
@@ -85,7 +85,13 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
 
         # Store the chosen device for future reference
         TaichiBackend._device = device
-    
+        
+    @staticmethod
+    def device_type(field: ti.Field, /):  # type: ignore
+        arch = ti.cfg.arch
+        device = "cpu" if arch == ti.cpu else "cuda" if arch == ti.cuda else str(arch)
+        return device
+
     @staticmethod
     def to_numpy(field: ti.Field, /) -> np.ndarray:
         """
@@ -99,4 +105,4 @@ class TaichiBackend(BackendProxy, backend_name='taichi'):
         """
         return field.to_numpy()
 
-    
+   

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -57,22 +57,6 @@ def test_context():
     assert ctx['device'] == 'cpu'
     
     print(ctx)
-    
-# 测试 to_numpy 方法
-def test_to_numpy():
-    x = ti.field(dtype=ti.f32, shape=(2, 3))
-    # 填充数据
-    @ti.kernel
-    def fill():
-        for i, j in x:
-            x[i, j] = i * 1.0 + j * 0.1
-    fill()
-
-    print("taichi data type: ", x.dtype)  # 输出 Taichi 的 dtype
-    np_x = bm.to_numpy(x)
-    print("taichi data to numpy type: ", np_x.dtype)
-    assert isinstance(np_x, np.ndarray)
-    assert np.allclose(np_x, np.array([[0.0, 0.1, 0.2], [1.0, 1.1, 1.2]]))  
 
 #测试 device_type 方法
 def test_device_type():
@@ -92,6 +76,107 @@ def test_device_type():
     assert dt== "cpu"
 
     print(dt)
+
+# 测试 to_numpy 方法
+def test_to_numpy():
+    x = ti.field(dtype=ti.f32, shape=(2, 3))
+    # 填充数据
+    @ti.kernel
+    def fill():
+        for i, j in x:
+            x[i, j] = i * 1.0 + j * 0.1
+    fill()
+
+    print("taichi data type: ", x.dtype)  # 输出 Taichi 的 dtype
+    np_x = bm.to_numpy(x)
+    print("taichi data to numpy type: ", np_x.dtype)
+    assert isinstance(np_x, np.ndarray)
+    assert np.allclose(np_x, np.array([[0.0, 0.1, 0.2], [1.0, 1.1, 1.2]]))  
+
+
+
+# 测试 ones 方法
+def test_ones():
+    # 测试不同维度的情况
+    for shape in [3, (2, 3), (2, 3, 4)]:
+        x = bm.ones(shape)
+        print(x)
+        # 测试 x 的数据类型是否为 ti.Field
+        assert isinstance(x, ti.Field)
+
+        # 使用 Taichi 内核验证 x 里的元素是否全为整型 1
+        @ti.kernel
+        def check_all_ones() -> bool:
+            all_ones = True
+            for I in ti.grouped(x):
+                if x[I] != 1 or ti.cast(x[I], ti.f32) != 1.0:
+                    all_ones = False
+            return all_ones
+
+        result = check_all_ones()
+        assert result == True
+
+# 测试 full 方法
+def test_full():
+# 测试布尔类型填充
+    shape = (3, 3)
+    element = True
+    x = bm.full(shape, element)
+    assert isinstance(x, ti.Field)
+    assert x.dtype == ti.u8
+    assert np.all(x.to_numpy() == 1)
+
+    # 测试整数类型填充
+    shape = (2, 2)
+    element = 5
+    x = bm.full(shape, element)
+    assert isinstance(x, ti.Field)
+    assert x.dtype == ti.i32
+    assert np.all(x.to_numpy() == 5)
+
+    # 测试浮点数类型填充
+    shape = (4,)
+    element = 3.14
+    x = bm.full(shape, element)
+    assert isinstance(x, ti.Field)
+    assert x.dtype == ti.f64
+    assert np.allclose(x.to_numpy(), 3.14)
+
+    # 测试自定义 dtype
+    shape = (3, 3)
+    element = 10
+    custom_dtype = ti.f32
+    x = bm.full(shape, element, dtype=custom_dtype)
+    assert isinstance(x, ti.Field)
+    assert x.dtype == ti.f32
+    assert np.all(x.to_numpy() == 10)
+
+    # 测试不支持的元素类型
+    shape = (2, 2)
+    element = "invalid"
+    with pytest.raises(TypeError, match="Unsupported fill_value type."):
+        bm.full(shape, element)
+
+    # 测试标量 shape
+    shape = 5
+    element = 1
+    x = bm.full(shape, element)
+    assert x.shape == (5,)
+    assert np.all(x.to_numpy() == 1)
+
+    # 测试空 shape
+    shape = ()
+    element = 0
+    x = bm.full(shape, element)
+    assert x.shape == ()
+    assert x.to_numpy() == 0
+
+    # 测试多维 shape
+    shape = (2, 3, 4)
+    element = 7
+    x = bm.full(shape, element)
+    assert x.shape == (2, 3, 4)
+    assert np.all(x.to_numpy() == 7)
 
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -276,6 +276,38 @@ def test_full_like():
     assert x.shape == (2, 3, 4)
     assert np.all(x.to_numpy() == 7)
 
+# 测试 acosh 方法
+def test_acosh():
+    # 测试标量输入且值在定义域内的情况
+    x_scalar = 2.0
+    result_scalar = bm.acosh(x_scalar)
+    expected_scalar = np.arccosh(x_scalar)
+    assert np.isclose(result_scalar, expected_scalar)
+
+    # 测试标量输入但值不在定义域内的情况
+    x_invalid_scalar = 0.5
+    with pytest.raises(ValueError, match="must be >= 1.0"):
+        bm.acosh(x_invalid_scalar)
+
+    # 测试 ti.Field 输入且所有值都在定义域内的情况
+    x_field = ti.field(dtype=ti.f32, shape=(3,))
+    x_field.from_numpy(np.array([1.5, 2.0, 3.0], dtype=np.float32))
+    result_field = bm.acosh(x_field)
+    expected_field = np.arccosh(x_field.to_numpy())
+    assert isinstance(result_field, ti.Field)
+    assert np.allclose(result_field.to_numpy(), expected_field)
+
+    # 测试 ti.Field 输入但部分值不在定义域内的情况
+    x_invalid_field = ti.field(dtype=ti.f32, shape=(3,))
+    x_invalid_field.from_numpy(np.array([0.5, 2.0, 3.0], dtype=np.float32))
+    with pytest.raises(ValueError, match="must be >= 1.0"):
+        bm.acosh(x_invalid_field)
+
+    # 测试输入类型无效的情况
+    x_invalid_type = np.array([1.0, 2.0])
+    with pytest.raises(TypeError, match="must be a ti.Field or a float"):
+        bm.acosh(x_invalid_type)
+
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])
 

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -74,7 +74,24 @@ def test_to_numpy():
     assert isinstance(np_x, np.ndarray)
     assert np.allclose(np_x, np.array([[0.0, 0.1, 0.2], [1.0, 1.1, 1.2]]))  
 
+#测试 device_type 方法
+def test_device_type():
+    x = ti.field(dtype=ti.f32, shape=(2, 3))
 
+    # 填充数据
+    @ti.kernel
+    def fill():
+        for i, j in x:
+            x[i, j] = i * 1.0 + j * 0.1
+
+    fill()
+
+    dt = bm.device_type(x)
+
+    # device 应为 'cpu'
+    assert dt== "cpu"
+
+    print(dt)
 
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -335,6 +335,50 @@ def test_asinh():
     with pytest.raises(TypeError, match="must be a ti.Field or a float"):
         bm.asinh(x_invalid_type)
 
+# 测试 add 方法
+def test_add():
+    # 测试两个形状相同的 ti.Field 相加成功的情况
+    x = ti.field(dtype=ti.f32, shape=(3, 3))
+    y = ti.field(dtype=ti.f32, shape=(3, 3))
+    # 初始化值
+    for i in range(3):
+        for j in range(3):
+            x[i, j] = i + j
+            y[i, j] = (i + j) * 2
+    # 执行相加
+    result = bm.add(x, y)
+    # 验证结果
+    for i in range(3):
+        for j in range(3):
+            assert result[i, j] == x[i, j] + y[i, j]
+
+    # 测试两个形状不同的 ti.Field 相加时抛出 ValueError
+    x = ti.field(dtype=ti.f32, shape=(2, 2))
+    y = ti.field(dtype=ti.f32, shape=(3, 3))
+    with pytest.raises(ValueError, match="Input fields must have the same shape"):
+        bm.add(x, y)
+
+    # 测试输入类型不是 ti.Field 时抛出 TypeError
+    x = np.array([1, 2, 3])
+    y = np.array([4, 5, 6])
+    with pytest.raises(TypeError, match="Both inputs must be ti.Field"):
+        bm.add(x, y)
+
+    # 测试不同数据类型的 ti.Field 相加（如果允许）
+    x = ti.field(dtype=ti.f32, shape=(2, 2))
+    y = ti.field(dtype=ti.i32, shape=(2, 2))
+    # 初始化值
+    for i in range(2):
+        for j in range(2):
+            x[i, j] = 1.5
+            y[i, j] = 2
+    result = bm.add(x, y)
+    # 验证结果是否自动提升类型
+    assert result.dtype == ti.f32
+    for i in range(2):
+        for j in range(2):
+            assert result[i, j] == pytest.approx(3.5)
+
 
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -226,7 +226,55 @@ def test_ones_like():
         assert ones_like.shape == (2,)
         assert np.all(ones_like.to_numpy() == 1)
 
-    
+# 测试 full_like 方法
+def test_full_like():
+    # 测试布尔类型填充
+    x_bool = ti.field(dtype=ti.i32, shape=(3, 3))
+    element_bool = True
+    x = bm.full_like(x_bool, element_bool)
+    assert isinstance(x, ti.Field)
+    assert x.dtype == ti.u8
+    assert np.all(x.to_numpy() == 1)
+
+    # 测试整数类型填充
+    x_int = ti.field(dtype=ti.f32, shape=(2, 2))
+    element_int = 5
+    x = bm.full_like(x_int, element_int)
+    assert isinstance(x, ti.Field)
+    assert x.dtype == ti.i32
+    assert np.all(x.to_numpy() == 5)
+
+    # 测试浮点数类型填充
+    x_float = ti.field(dtype=ti.i64, shape=(4,))
+    element_float = 3.14
+    x = bm.full_like(x_float, element_float)
+    assert isinstance(x, ti.Field)
+    assert x.dtype == ti.f64
+    assert np.allclose(x.to_numpy(), 3.14)
+
+    # 测试自定义 dtype
+    x_custom = ti.field(dtype=ti.i32, shape=(3, 3))
+    element_custom = 10
+    custom_dtype = ti.f32
+    x = bm.full_like(x_custom, element_custom, dtype=custom_dtype)
+    assert isinstance(x, ti.Field)
+    assert x.dtype == ti.f32
+    assert np.all(x.to_numpy() == 10)
+
+    # 测试不支持的元素类型
+    x_invalid = ti.field(dtype=ti.i32, shape=(2, 2))
+    element_invalid = "invalid"
+    with pytest.raises(TypeError, match="Unsupported fill_value type."):
+        bm.full_like(x_invalid, element_invalid)
+
+    # 测试多维场
+    x_multi = ti.field(dtype=ti.f32, shape=(2, 3, 4))
+    element_multi = 7
+    x = bm.full_like(x_multi, element_multi)
+    assert isinstance(x, ti.Field)
+    assert x.dtype == ti.i32
+    assert x.shape == (2, 3, 4)
+    assert np.all(x.to_numpy() == 7)
 
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -178,6 +178,56 @@ def test_full():
     assert x.shape == (2, 3, 4)
     assert np.all(x.to_numpy() == 7)
 
+# 测试 ones_like 方法
+def test_ones_like():
+    # 测试标量场
+    x_scalar = ti.field(dtype=ti.i32, shape=())
+    x_scalar[None] = 5
+    ones_like_scalar = bm.ones_like(x_scalar)
+    assert isinstance(ones_like_scalar, ti.Field)
+    assert ones_like_scalar.dtype == ti.i32
+    assert ones_like_scalar.shape == ()
+    assert ones_like_scalar[None] == 1
+
+    # 测试一维场
+    x_1d = ti.field(dtype=ti.f32, shape=(5,))
+    @ti.kernel
+    def fill_1d():
+        for i in x_1d:
+            x_1d[i] = 2.0
+    fill_1d()
+    ones_like_1d = bm.ones_like(x_1d)
+    assert isinstance(ones_like_1d, ti.Field)
+    assert ones_like_1d.dtype == ti.i32
+    assert ones_like_1d.shape == (5,)
+    assert np.all(ones_like_1d.to_numpy() == 1.0)
+
+    # 测试二维场
+    x_2d = ti.field(dtype=ti.i64, shape=(3, 4))
+    @ti.kernel
+    def fill_2d():
+        for i, j in x_2d:
+            x_2d[i, j] = 10
+    fill_2d()
+    ones_like_2d = bm.ones_like(x_2d)
+    assert isinstance(ones_like_2d, ti.Field)
+    assert ones_like_2d.dtype == ti.i32
+    assert ones_like_2d.shape == (3, 4)
+    assert np.all(ones_like_2d.to_numpy() == 1)
+
+    # 测试不同数据类型
+    dtypes = [ti.i8, ti.i16, ti.i32, ti.i64, ti.u8, ti.u16, ti.u32, ti.u64, ti.f32, ti.f64]
+    for dtype in dtypes:
+        x = ti.field(dtype=dtype, shape=(2,))
+        x.fill(100)
+        ones_like = bm.ones_like(x)
+        assert isinstance(ones_like, ti.Field)
+        assert ones_like.dtype == ti.i32
+        assert ones_like.shape == (2,)
+        assert np.all(ones_like.to_numpy() == 1)
+
+    
+
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])
 

--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -308,6 +308,34 @@ def test_acosh():
     with pytest.raises(TypeError, match="must be a ti.Field or a float"):
         bm.acosh(x_invalid_type)
 
+# 测试 asinh 方法
+def test_asinh():
+    # 测试标量输入情况
+    x_scalar = 1.0
+    result_scalar = bm.asinh(x_scalar)
+    expected_scalar = np.arcsinh(x_scalar)
+    assert np.isclose(result_scalar, expected_scalar)
+
+    # 测试标量输入边界值情况
+    x_boundary = 0.0
+    result_boundary = bm.asinh(x_boundary)
+    expected_boundary = np.arcsinh(x_boundary)
+    assert np.isclose(result_boundary, expected_boundary)
+
+    # 测试 ti.Field 输入且所有值都在定义域内的情况
+    x_field = ti.field(dtype=ti.f32, shape=(3,))
+    x_field.from_numpy(np.array([0.5, 1.0, 1.5], dtype=np.float32))
+    result_field = bm.asinh(x_field)
+    expected_field = np.arcsinh(x_field.to_numpy())
+    assert isinstance(result_field, ti.Field)
+    assert np.allclose(result_field.to_numpy(), expected_field)
+
+    # 测试输入类型无效的情况
+    x_invalid_type = np.array([1.0, 2.0])
+    with pytest.raises(TypeError, match="must be a ti.Field or a float"):
+        bm.asinh(x_invalid_type)
+
+
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])
 


### PR DESCRIPTION
This submission completes the testing of  8 functions:device_type,  ones, full, ones_like,full_like,acosh,asinh and add. The specific details are as follows:
device_type Function：
Tested the device type detection logic by creating Taichi fields of different dimensions and ensuring accurate detection of the underlying device (CPU in this case). Validated that the conversion from Taichi's internal representation to the expected device type string ("cpu") works as intended.
ones Function：
Tested the ones method by creating arrays of different dimensions (scalar, 2D, 3D) and ensuring they are initialized as Taichi fields filled with integer 1s. Validated the data type and element values using Taichi kernels to check for exact integer and floating-point equality.
full Function
Tested the full method across various data types (bool, int, float) and dimensions (scalar, empty, multi-dimensional), ensuring correct Taichi field creation and element initialization. Validated type inference, explicit dtype specification, and error handling for unsupported types. Confirmed shape preservation and element value consistency using NumPy comparisons.
ones_like Function
Tested the ones_like method by creating new Taichi fields with the same shape as input fields of various dimensions (scalar, 1D, 2D) and data types (integers, floats). Ensured the output fields are initialized with integer 1s, maintaining the input's shape while defaulting to i32 dtype. Validated correctness using direct value checks and NumPy array comparisons.
full_like Function
Tested the full_like method by creating Taichi fields with the same shape as input fields while filling them with specified values of different data types (bool, int, float). Validated type inference, explicit dtype overrides, and error handling for unsupported types. Confirmed shape preservation and element value consistency using NumPy comparisons.
acosh Function
Tested the acosh method for both scalar and Taichi field inputs, ensuring accurate computation of the inverse hyperbolic cosine for valid values (≥1.0). Validated against NumPy's arccosh for correctness, enforced domain constraints through ValueError checks for invalid inputs, and confirmed proper error handling for unsupported input types (non-Taichi fields). Maintained type consistency and numerical precision using np.allclose for array comparisons.
asinh Function
Tested the asinh method for both scalar and Taichi field inputs, ensuring accurate computation of the inverse hyperbolic sine. Validated against NumPy's arcsinh for correctness, checked boundary conditions (e.g., zero input), and confirmed proper error handling for unsupported input types (non-Taichi fields). Maintained type consistency and numerical precision using np.allclose for array comparisons.
add Function
Tested element-wise addition for Taichi fields, ensuring correctness for matching shapes and data type promotion (e.g., float + int → float). Validated shape compatibility enforcement through ValueError checks, input type constraints via TypeError handling, and numerical accuracy using direct comparisons and pytest.approx for floating-point precision. Confirmed type consistency and error messages align with specifications.