### PR TITLE
[test] Test the functionality of original functions for Taichi (backend)

### DIFF
--- a/test/backend/test_taichi_backend.py
+++ b/test/backend/test_taichi_backend.py
@@ -92,226 +92,6 @@ def test_to_numpy():
     assert isinstance(np_x, np.ndarray)
     assert np.allclose(np_x, np.array([[0.0, 0.1, 0.2], [1.0, 1.1, 1.2]]))
     
-# 测试 from_numpy 方法
-class TestFromNumpy:
-    def test_from_numpy_float32(self):
-        # 初始化Taichi（如果尚未初始化）
-        ti.init(arch=ti.cpu)  # 使用CPU后端加速测试
-
-<<<<<<< HEAD
-# 测试 from_numpy 方法
-class TestFromNumpy:
-    def test_from_numpy_float32(self):
-        # 初始化Taichi（如果尚未初始化）
-        ti.init(arch=ti.cpu)  # 使用CPU后端加速测试
-=======
-        np_array = np.array([1.1, 2.2, 3.3], dtype=np.float32)
-        ti_field = bm.from_numpy(np_array)
-
-        # 检查数据类型
-        assert ti_field.dtype == ti.f32
-
-        # 检查形状
-        assert ti_field.shape == (3,)
-
-        # 检查数据内容（允许浮点数微小误差）
-        assert np.allclose(ti_field.to_numpy(), np_array)
-
-    def test_from_numpy_int32(self):
-        # 初始化Taichi
-        ti.init(arch=ti.cpu)  # 使用CPU后端加速测试
-
-        np_array = np.array([1, 2, 3], dtype=np.int32)
-        ti_field = bm.from_numpy(np_array)
-
-        # 检查数据类型
-        assert ti_field.dtype == ti.i32
-
-        # 检查形状
-        assert ti_field.shape == (3,)
-
-        # 检查数据内容
-        assert np.allclose(ti_field.to_numpy(), np_array)
-
-#测试 to_list 方法   
-class TestTolist:
-    def test_to_list_empty(self):
-        """测试空 Field 是否能正确转换为空列表"""
-        field = ti.field(ti.f32, shape=())
-        result = bm.to_list(field)
-        assert np.allclose(result, [])
-
-    def test_to_list_1d(self):
-        """测试 1D Field 是否能正确转换为列表"""
-        field = ti.field(ti.i32, shape=(3,))
-        field.from_numpy(np.array([1, 2, 3]))
-        assert bm.to_list(field) == [1, 2, 3]
-
-    def test_to_list_2d(self):
-        """测试 2D Field 是否能正确转换为列表"""
-        field = ti.field(ti.f32, shape = (2, 3))
-        field.from_numpy(np.array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]]))
-
-        # 允许浮点数微小误差
-        assert np.allclose(bm.to_list(field), [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]])
-
-#测试 arange 方法
-class TestArange():
-    def test_arange_simple(self):
-        """测试基础范围生成"""
-        field = bm.arange(10)
-        assert np.allclose(field.to_numpy(), np.arange(10))
-
-    def test_arange_step(self):
-        """测试带步长的范围生成"""
-        field = bm.arange(0, 10, 2)
-        assert np.allclose(field.to_numpy(), np.arange(0,10,2))
-
-    def test_arrange_empty(self):
-        """测试空范围生成"""
-        field = bm.arange(0)
-        assert field is None
-
-    def test_arange_invaild(self):
-        """测试无效范围生成"""
-        field = bm.arange(-1)
-        assert np.allclose(field, np.arange(-1))
-
-#测试 eye 函数
-class TestEye:
-    def test_eye_square(self):
-        """测试对角线为1的方阵"""
-        field = bm.eye(1)
-        assert np.allclose(field.to_numpy(), np.eye(1))
-
-    def test_eye_rectangle(self):
-        """"测试对角线为1的矩形"""
-        field = bm.eye(3,4)
-        assert np.allclose(field.to_numpy(),np.eye(3,4))
-
-    def test_eye_diagonal_offset(self):
-        """测试对角线偏移的方阵"""
-        field = bm.eye(3, k=1)
-        assert np.allclose(field.to_numpy(), np.eye(3, k=1))
-
-    def test_eye_empty(self):
-        """测试空方阵"""
-        field = bm.eye(0)
-        assert field is None
-
-#测试 Zeros 函数
-class TestZeros:
-    def test_zeros_1d(self):
-        """测试 1D 零矩阵"""
-        field = bm.zeros((3,))
-        assert np.allclose(field.to_numpy(), np.zeros((3,)))
-
-    def test_zeros_2d(self):
-        """测试 2D 零矩阵"""
-        field = bm.zeros((2, 3))
-        assert np.allclose(field.to_numpy(), np.zeros((2, 3)))
-
-    def test_zeros_empty(self):
-        """测试空矩阵"""
-        field = bm.zeros((0,))
-        assert field is None
-
-#测试 tril 函数
-class TestTril:
-    def test_tril_square(self):
-        """测试下三角方阵"""
-        field = bm.tril(3)
-        expected = np.array([[1,0,0],
-                             [1,1,0],
-                             [1,1,1]])
-        assert np.allclose(field.to_numpy(), expected)
-
-    def test_tril_rectangle(self):
-        """测试下三角矩阵"""
-        field = bm.tril(2,3)
-        expected = np.array([[1,0,0],
-                             [1,1,0]])
-        assert np.allclose(field.to_numpy(), expected)
-
-    def test_tril_diagonal_offset(self):
-        """测试下三角矩阵，偏移对角线"""
-        field = bm.tril(3, k=1)
-        expected = np.array([[1,1,0],
-                             [1,1,1],
-                             [1,1,1]])
-        assert np.allclose(field.to_numpy(), expected)
-
-    def test_tril_empty(self):
-        """测试空矩阵"""
-        field = bm.tril(0)
-        assert field is None
-
-#测试 abs 函数
-class TestAbs:
-    def test_abs_positive(self):
-        """测试正数元素的绝对值"""
-        field = ti.field(ti.f32, shape=(3,))
-        field.from_numpy(np.array([1.0, 2.0, 3.0]))
-        result = bm.abs(field)
-        assert np.allclose(result.to_numpy(), np.array([1.0, 2.0, 3.0]))
-
-    def test_abs_negative(self):    
-        """测试负数元素的绝对值"""
-        field = ti.field(ti.f32, shape=(3,))
-        field.from_numpy(np.array([-1, -2, -3]))        
-        result = bm.abs(field)
-        assert np.allclose(result.to_numpy(), np.array([1, 2, 3]))
-
-    def test_abs_empty(self):
-        """测试空元素的绝对值"""
-        field = ti.field(ti.f32, shape=())
-        result = bm.abs(field)
-        assert np.allclose(result.to_numpy(), np.abs(field.to_numpy()))
-
-    # def test_abs_complex(self):
-    #     """测试复数元素的绝对值"""
-    #     field = ti.field(ti.c64, shape=(3,))
-    #     field.from_numpy(np.array([1+2j, 2-1j, 3+0j]))
-    #     result = bm.abs(field)
-    #     assert np.allclose(result.to_numpy(), np.array([np.sqrt(5), np.sqrt(5), 3.0]))
-
-#测试 acos 函数
-class TestAcos:
-    def test_acos_normal_values(self):
-        """测试常规值"""
-        field = ti.field(ti.f32, shape=(3,))
-        field.from_numpy(np.array([0.5, -0.7, 0.9]))
-        result = bm.acos(field)
-        assert np.allclose(result.to_numpy(), np.arccos(np.array([0.5, -0.7, 0.9])))
-
-    def test_acos_boundary_values(self):
-        """测试边界值"""
-        field = ti.field(ti.f32, shape=(2,))
-        field.from_numpy(np.array([1.0, -1.0]))
-        result = bm.acos(field)
-        assert np.allclose(result.to_numpy(), np.arccos(np.array([1.0, -1.0])))
-
-    def test_acos_empty(self):
-        """测试空元素"""
-        field = ti.field(ti.f32, shape=())
-        field[None] = 0.5
-        result = bm.acos(field)
-        assert np.allclose(result.to_numpy(), np.arccos(0.5))
-
-#测试 zeros_like 函数
-class TestZerosLike:
-    def test_zeros_like_normal(self):
-        """测试常规情况"""
-        field = ti.field(ti.f32, shape=(2, 3))
-        result = bm.zeros_like(field)
-        assert np.allclose(result.to_numpy(), np.zeros((2, 3)))
-
-    def test_zeros_like_empty(self):
-        """测试空元素"""
-        field = ti.field(ti.f32, shape=())
-        result = bm.zeros_like(field)
-        assert np.allclose(result.to_numpy(), np.zeros_like(field.to_numpy()))
-
 # 测试 ones 方法
 def test_ones():
     # 测试不同维度的情况
@@ -595,7 +375,6 @@ def test_add():
     for i in range(2):
         for j in range(2):
             assert result[i, j] == pytest.approx(3.5)
->>>>>>> swh/taichi
 
         np_array = np.array([1.1, 2.2, 3.3], dtype=np.float32)
         ti_field = bm.from_numpy(np_array)
@@ -624,185 +403,297 @@ def test_add():
 
         # 检查数据内容
         assert np.allclose(ti_field.to_numpy(), np_array)
+        
+# 测试 from_numpy 方法
+class TestFromNumpy:
+    def test_from_numpy_dtype(self):
+        """测试从 NumPy 数组创建不同的数据类型 field"""
+        # float型1d
+        arr = np.array([1.1, 2.2, 3.3], dtype=np.float32)
+        field = bm.from_numpy(arr)
+        assert np.array_equal(field.to_numpy(), arr)
 
-#测试 to_list 方法   
+        # int型2d
+        arr = np.array([[1, 2],[3,4]], dtype=np.int32)
+        field = bm.from_numpy(arr)
+        assert np.array_equal(field.to_numpy(), arr)
+
+        # bool型
+        arr = np.array([True, False, True], dtype=np.bool)
+        field = bm.from_numpy(arr)
+        assert np.array_equal(field.to_numpy(), arr)
+
+    def test_from_numpy_3d(self):
+        """测试从 3D NumPy 数组创建 field"""
+        arr = np.random.rand(2, 3, 4)
+        field = bm.from_numpy(arr)
+        assert np.array_equal(field.to_numpy(), arr)
+
+# 测试 tolist 方法   
 class TestTolist:
-    def test_to_list_empty(self):
-        """测试空 Field 是否能正确转换为空列表"""
+    def test_tolist_empty(self):
+        """测试标量是否能正确转换为列表"""
         field = ti.field(ti.f32, shape=())
-        result = bm.to_list(field)
-        assert np.allclose(result, [])
+        field[None] = 1.1
+        assert np.allclose(bm.tolist(field), np.array(1.1))
 
-    def test_to_list_1d(self):
+    def test_tolist_1d(self):
         """测试 1D Field 是否能正确转换为列表"""
         field = ti.field(ti.i32, shape=(3,))
         field.from_numpy(np.array([1, 2, 3]))
-        assert bm.to_list(field) == [1, 2, 3]
+        assert np.array_equal(bm.tolist(field), np.array([1, 2, 3]))
 
-    def test_to_list_2d(self):
+    def test_tolist_2d(self):
         """测试 2D Field 是否能正确转换为列表"""
         field = ti.field(ti.f32, shape = (2, 3))
         field.from_numpy(np.array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]]))
+        # 允许浮点数存在微笑误差
+        assert np.allclose(bm.tolist(field), np.array([[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]]))
 
-        # 允许浮点数微小误差
-        assert np.allclose(bm.to_list(field), [[1.1, 2.2, 3.3], [4.4, 5.5, 6.6]])
+    def test_tolist_3d(self):
+        """测试 3D Field 是否能正确转换为列表"""
+        field = ti.field(ti.f32, shape = (2, 3, 4))
+        field.from_numpy(np.random.rand(2, 3, 4))
+        assert np.array_equal(bm.tolist(field), field.to_numpy())
 
-#测试 arange 方法
+# 测试 arange 方法
 class TestArange():
-    def test_arange_simple(self):
+    def test_arange_valid(self):
         """测试基础范围生成"""
+        # 一个参数
         field = bm.arange(10)
-        assert np.allclose(field.to_numpy(), np.arange(10))
+        assert np.array_equal(field.to_numpy(), np.arange(10))
 
-    def test_arange_step(self):
-        """测试带步长的范围生成"""
+        # 两个参数
+        field = bm.arange(0, 10)
+        assert np.array_equal(field.to_numpy(), np.arange(0,10))
+
+        # 三个参数
         field = bm.arange(0, 10, 2)
-        assert np.allclose(field.to_numpy(), np.arange(0,10,2))
+        assert np.array_equal(field.to_numpy(), np.arange(0,10,2))
 
-    def test_arrange_empty(self):
-        """测试空范围生成"""
+    def test_arange_boudary(self):
+        """测试边界范围生成"""
+        # 单参数为 0
         field = bm.arange(0)
-        assert field is None
+        assert np.array_equal(field, np.arange(0))
+
+        # 单参数为负数
+        field = bm.arange(-10)
+        assert np.array_equal(field, np.arange(-10))
+
+        # 双参数中 N>M
+        field = bm.arange(10, 0)
+        assert np.array_equal(field, np.arange(10, 0))
+
+        # 三参数中 N>M
+        field = bm.arange(10, 0, 2)
+        assert np.array_equal(field, np.arange(10, 0, 2))
 
     def test_arange_invaild(self):
         """测试无效范围生成"""
-        field = bm.arange(-1)
-        assert np.allclose(field, np.arange(-1))
+        # 无参数
+        with pytest.raises(ValueError, match="arange\(\) requires stop to be specified."):
+            bm.arange(None)
 
-#测试 eye 函数
+        # 参数大于 3
+        with pytest.raises(ValueError, match="arange expects 1~3 arguments \(stop \| start, stop \| start, stop, step\)"):
+            bm.arange(1,3,5,7,9)
+
+        # 步长为 0
+        with pytest.raises(ValueError, match="step must not be zero"):
+            bm.arange(1,3,0)
+
+
+# 测试 eye 函数
 class TestEye:
-    def test_eye_square(self):
-        """测试对角线为1的方阵"""
-        field = bm.eye(1)
-        assert np.allclose(field.to_numpy(), np.eye(1))
+    def test_eye_valid(self):
+        """测试基础元素的单位阵"""
+        # 测试 3 阶单位阵
+        field = bm.eye(3)
+        assert np.array_equal(field.to_numpy(), np.eye(3))
 
-    def test_eye_rectangle(self):
-        """"测试对角线为1的矩形"""
+        # 测试 3 行 4 列单位阵
         field = bm.eye(3,4)
-        assert np.allclose(field.to_numpy(),np.eye(3,4))
+        assert np.array_equal(field.to_numpy(),np.eye(3,4))
 
-    def test_eye_diagonal_offset(self):
-        """测试对角线偏移的方阵"""
+        # 测试 3 行 4 列单位阵，偏移对角线
         field = bm.eye(3, k=1)
-        assert np.allclose(field.to_numpy(), np.eye(3, k=1))
+        assert np.array_equal(field.to_numpy(), np.eye(3, k=1))
 
-    def test_eye_empty(self):
-        """测试空方阵"""
+    def test_eye_boundary(self): 
+        """测试边界元素的单位阵"""
+        # 测试空矩阵  # TODO
         field = bm.eye(0)
-        assert field is None
+        assert np.array_equal(field, np.array([]))
+        # N = 0
+        field = bm.eye(0, 3)
+        assert np.array_equal(field, np.array([]))
+        # M = 0
+        field = bm.eye(3, 0)
+        assert np.array_equal(field, np.array([]))
 
-#测试 Zeros 函数
+
+
+    def test_eye_invalid(self):
+        """测试无效输入"""
+        # N 为 None
+        with pytest.raises(ValueError, match="Both N and M are None. At least one dimension must be specified for eye()."):
+            bm.eye(None)
+
+        # N 为负数
+        with pytest.raises(ValueError, match="N and M must be positive integers, got N=-1, M=3"):
+            bm.eye(-1,3)
+
+        # N 不是 int 型
+        with pytest.raises(TypeError, match="N and M must be integers, got N=1.2, M=1.2"):
+            bm.eye(1.2)
+
+
+# 测试 zeros 函数
 class TestZeros:
-    def test_zeros_1d(self):
-        """测试 1D 零矩阵"""
-        field = bm.zeros((3,))
-        assert np.allclose(field.to_numpy(), np.zeros((3,)))
+    def test_zeros_valid(self):
+        """测试基础元素的零值"""
+        # 测试3阶零方阵
+        field = bm.zeros(3)
+        assert np.allclose(field.to_numpy(), np.zeros(3))
 
-    def test_zeros_2d(self):
-        """测试 2D 零矩阵"""
+        #测试2行3列零矩阵
         field = bm.zeros((2, 3))
         assert np.allclose(field.to_numpy(), np.zeros((2, 3)))
 
-    def test_zeros_empty(self):
-        """测试空矩阵"""
-        field = bm.zeros((0,))
-        assert field is None
+        #测试空矩阵
+        field = bm.zeros(0)
+        assert np.allclose(field, np.zeros(0))
 
-#测试 tril 函数
+    def test_zeros_invalid(self):
+        """测试无效输入"""
+        #shape为-1
+        with pytest.raises(ValueError, match="Shape must be a non-negative integer, got (-1)."):
+            bm.zeros((-1))
+
+
+# 测试 tril 函数
 class TestTril:
-    def test_tril_square(self):
-        """测试下三角方阵"""
-        field = bm.tril(3)
-        expected = np.array([[1,0,0],
-                             [1,1,0],
-                             [1,1,1]])
-        assert np.allclose(field.to_numpy(), expected)
+    def test_tril_valid(self):
+        # 测试下三角 3 阶方阵
+        field = ti.field(ti.i32, shape = (3,))
+        field.from_numpy(np.array([1,2,3]))
+        result = bm.tril(field)
+        assert np.array_equal(result.to_numpy(), np.tril(np.array([1,2,3])))
 
-    def test_tril_rectangle(self):
-        """测试下三角矩阵"""
-        field = bm.tril(2,3)
-        expected = np.array([[1,0,0],
-                             [1,1,0]])
-        assert np.allclose(field.to_numpy(), expected)
+        # 测试下三角 2 行 3 列矩形
+        field = ti.field(ti.f32, shape=(2, 3))
+        field.from_numpy(np.array([[1.0,2.0,3.0],
+                                   [4.0,5.0,6.0]]))
+        result = bm.tril(field)
+        assert np.array_equal(result.to_numpy(), np.tril(np.array([[1.0,2.0,3.0],
+                                                                   [4.0,5.0,6.0]])))
 
-    def test_tril_diagonal_offset(self):
-        """测试下三角矩阵，偏移对角线"""
-        field = bm.tril(3, k=1)
-        expected = np.array([[1,1,0],
-                             [1,1,1],
-                             [1,1,1]])
-        assert np.allclose(field.to_numpy(), expected)
+        # 测试下三角 3 阶方阵，偏移对角线
+        field = ti.field(ti.i32, shape=(3, 3)) 
+        field.from_numpy(np.array([[1,2,3],
+                                   [4,5,6],
+                                   [7,8,9]]))
+        result = bm.tril(field, k=-1)
+        assert np.array_equal(result.to_numpy(), np.tril(np.array([[1,2,3],
+                                                                   [4,5,6],
+                                                                   [7,8,9]]), k=-1))
 
-    def test_tril_empty(self):
-        """测试空矩阵"""
-        field = bm.tril(0)
-        assert field is None
+    def test_tril_invalid(self):
+        """测试无效输入"""
+        # shape 为 3d
+        field = ti.field(ti.f32, shape=(2, 3, 4))
+        with pytest.raises(ValueError, match="Input field with shape \(2, 3, 4\) is not supported\. Only 1D and 2D fields are supported\."):
+            bm.tril(field)
 
-#测试 abs 函数
+        # field 为标量
+        field = ti.field(ti.f32, shape=())
+        with pytest.raises(ValueError, match="Input field is a scalar \(0D\)\, tril is not defined for scalars\."):
+            bm.tril(field)
+
+        # field 为 None
+        with pytest.raises(ValueError, match="Input field is None. Please provide a valid Taichi field."):
+            bm.tril(None)
+
+
+
+# 测试 abs 函数
 class TestAbs:
-    def test_abs_positive(self):
-        """测试正数元素的绝对值"""
+    def test_abs_valid(self):
+        """测试基础元素的绝对值"""
+        # 测试正数浮点数的绝对值
         field = ti.field(ti.f32, shape=(3,))
         field.from_numpy(np.array([1.0, 2.0, 3.0]))
         result = bm.abs(field)
-        assert np.allclose(result.to_numpy(), np.array([1.0, 2.0, 3.0]))
+        assert np.array_equal(result.to_numpy(), np.array([1.0, 2.0, 3.0]))
 
-    def test_abs_negative(self):    
-        """测试负数元素的绝对值"""
+        # 测试负数整数的绝对值
         field = ti.field(ti.f32, shape=(3,))
         field.from_numpy(np.array([-1, -2, -3]))        
         result = bm.abs(field)
-        assert np.allclose(result.to_numpy(), np.array([1, 2, 3]))
+        assert np.array_equal(result.to_numpy(), np.array([1, 2, 3]))
 
-    def test_abs_empty(self):
-        """测试空元素的绝对值"""
-        field = ti.field(ti.f32, shape=())
+        # 测试零元素的绝对值
+        field = ti.field(ti.i32, shape=())
+        field[None] = 0
         result = bm.abs(field)
-        assert np.allclose(result.to_numpy(), np.abs(field.to_numpy()))
+        assert np.array_equal(result.to_numpy(), np.array(0))
 
-    # def test_abs_complex(self):
-    #     """测试复数元素的绝对值"""
-    #     field = ti.field(ti.c64, shape=(3,))
-    #     field.from_numpy(np.array([1+2j, 2-1j, 3+0j]))
-    #     result = bm.abs(field)
-    #     assert np.allclose(result.to_numpy(), np.array([np.sqrt(5), np.sqrt(5), 3.0]))
+    def test_abs_invalid(self):
+        """测试无效输入"""
+        # 无参数
+        with pytest.raises(ValueError, match="Input field is None. Please provide a valid Taichi field."):
+            bm.abs(None)
 
 #测试 acos 函数
 class TestAcos:
-    def test_acos_normal_values(self):
+    def test_acos_valid(self):
         """测试常规值"""
         field = ti.field(ti.f32, shape=(3,))
         field.from_numpy(np.array([0.5, -0.7, 0.9]))
         result = bm.acos(field)
         assert np.allclose(result.to_numpy(), np.arccos(np.array([0.5, -0.7, 0.9])))
 
-    def test_acos_boundary_values(self):
+    def test_acos_boundary(self):
         """测试边界值"""
+        # 测试 1.0 和 -1.0
         field = ti.field(ti.f32, shape=(2,))
         field.from_numpy(np.array([1.0, -1.0]))
         result = bm.acos(field)
         assert np.allclose(result.to_numpy(), np.arccos(np.array([1.0, -1.0])))
 
-    def test_acos_empty(self):
-        """测试空元素"""
-        field = ti.field(ti.f32, shape=())
-        field[None] = 0.5
-        result = bm.acos(field)
-        assert np.allclose(result.to_numpy(), np.arccos(0.5))
+    def test_acos_invalid(self):
+        """测试无效输入"""
+        # 无参数
+        with pytest.raises(ValueError, match="Input field is None. Please provide a valid Taichi field."):
+            bm.acos(None)
+
+        # 参数为一维空数组
+        field = ti.field(ti.f32, shape=(1,))
+        with pytest.raises(ValueError, match="ti\.field shape \(1,\) does not match the numpy array shape \(0,\)"):
+            result = field.from_numpy(np.array([]))
+            bm.acos(result)
 
 #测试 zeros_like 函数
 class TestZerosLike:
-    def test_zeros_like_normal(self):
+    def test_zeros_like_valid(self):
         """测试常规情况"""
+        # 测试3阶方阵
+        field = ti.field(ti.f32, shape=(3,))
+        result = bm.zeros_like(field)
+        assert np.array_equal(result.to_numpy(), np.zeros(3))
+
+        # 测试2行3列矩阵
         field = ti.field(ti.f32, shape=(2, 3))
         result = bm.zeros_like(field)
-        assert np.allclose(result.to_numpy(), np.zeros((2, 3)))
+        assert np.array_equal(result.to_numpy(), np.zeros((2, 3)))
 
-    def test_zeros_like_empty(self):
-        """测试空元素"""
-        field = ti.field(ti.f32, shape=())
-        result = bm.zeros_like(field)
-        assert np.allclose(result.to_numpy(), np.zeros_like(field.to_numpy()))
+    def test_zeros_like_invalid(self):
+        """测试无效输入"""
+        # 无参数
+        with pytest.raises(ValueError, match="Input field is None. Please provide a valid Taichi field."):
+            bm.zeros_like(None)
         
 if __name__ == '__main__':
     pytest.main(['-q', '-s'])


### PR DESCRIPTION
This PR focuses on optimizing the test coverage for Taichi backend's fundamental functions, including from_numpy, tolist, arange, eye, zeros, zeros_like, tril, acos, and abs.

Key modifications:
Standardized the code formatting style across all test cases to ensure consistency.
Added test scenarios for edge cases and exception handling.

All tests have been successfully executed and passed.